### PR TITLE
Chore/remove test warnings

### DIFF
--- a/src/eq.rs
+++ b/src/eq.rs
@@ -23,22 +23,22 @@ pub struct EqKey {
 }
 
 impl RawKey for EqKey {
-    const key_len: usize = 621;
+    const KEY_LEN: usize = 621;
 
     unsafe fn to_raw_line(&self, key_pointer: *mut u8) {
         // Cast the output line to a raw pointer.
-        let out_ptr: *mut [u8; Self::key_len] =
-            slice::from_raw_parts_mut(key_pointer, Self::key_len).as_mut_ptr()
-                as *mut [u8; Self::key_len];
+        let out_ptr: *mut [u8; Self::KEY_LEN] =
+            slice::from_raw_parts_mut(key_pointer, Self::KEY_LEN).as_mut_ptr()
+                as *mut [u8; Self::KEY_LEN];
         // Get a mutable reference.
-        let out_ref: &mut [u8; Self::key_len] = &mut *out_ptr;
+        let out_ref: &mut [u8; Self::KEY_LEN] = &mut *out_ptr;
         // Write the key.
         write_key_to_array(&self, out_ref);
     }
 
     unsafe fn from_raw_line(key_pointer: *const u8) -> Self {
-        let key_ptr = slice::from_raw_parts(key_pointer, Self::key_len).as_ptr()
-            as *const [u8; Self::key_len];
+        let key_ptr = slice::from_raw_parts(key_pointer, Self::KEY_LEN).as_ptr()
+            as *const [u8; Self::KEY_LEN];
         read_key_from_array(&*key_ptr)
     }
 }
@@ -129,7 +129,7 @@ impl FSSKey for EqKey {
 /// Serialization
 ///
 
-fn write_key_to_array(key: &EqKey, array: &mut [u8; EqKey::key_len]) {
+fn write_key_to_array(key: &EqKey, array: &mut [u8; EqKey::KEY_LEN]) {
     array[0..N].copy_from_slice(&key.alpha_share.to_le_bytes());
     array[N..(N + L)].copy_from_slice(&key.s.to_le_bytes());
     for i in 0..(N * 8) {
@@ -140,12 +140,12 @@ fn write_key_to_array(key: &EqKey, array: &mut [u8; EqKey::key_len]) {
         array[cw_end - 2] = key.t_l[i];
         array[cw_end - 1] = key.t_r[i];
     }
-    // array[EqKey::key_len - 1] = key.t_leaf;
-    let j = EqKey::key_len - N;
+    // array[EqKey::KEY_LEN - 1] = key.t_leaf;
+    let j = EqKey::KEY_LEN - N;
     array[j..j + N].copy_from_slice(&key.cw_leaf.to_le_bytes());
 }
 
-fn read_key_from_array(array: &[u8; EqKey::key_len]) -> EqKey {
+fn read_key_from_array(array: &[u8; EqKey::KEY_LEN]) -> EqKey {
     let alpha_share = u32::from_le_bytes(array[0..N].try_into().unwrap());
     let s = u128::from_le_bytes(array[N..(N + L)].try_into().unwrap());
 
@@ -161,8 +161,8 @@ fn read_key_from_array(array: &[u8; EqKey::key_len]) -> EqKey {
         t_r[i] = array[cw_end - 1];
     }
 
-    // let t_leaf = array[EqKey::key_len - 1];
-    let j = EqKey::key_len - N;
+    // let t_leaf = array[EqKey::KEY_LEN - 1];
+    let j = EqKey::KEY_LEN - N;
     let cw_leaf = u32::from_le_bytes(array[j..j + N].try_into().unwrap());
 
     EqKey {

--- a/src/le.rs
+++ b/src/le.rs
@@ -92,8 +92,8 @@ impl FSSKey for LeKey {
         assert!((party_id == 0u8) || (party_id == 1u8));
         let mut t_i: u8 = party_id;
         let mut s_i: u128 = self.s;
-        let mut u_i = 0u8;
-        let mut z_i = 0u32;
+        let mut u_i;
+        let mut z_i;
         let mut out = 0u32;
         let x_bits: Vec<u8> = bit_decomposition_u32(x);
         for i in 0..(N * 8) {

--- a/src/le.rs
+++ b/src/le.rs
@@ -38,22 +38,22 @@ const CW_LEN: usize = 24;
 
 impl RawKey for LeKey {
     // 4 + 16 + 24 * (4 * 8) + 4 * (4 * 8 + 1)
-    const key_len: usize = 920;
+    const KEY_LEN: usize = 920;
 
     unsafe fn to_raw_line(&self, key_pointer: *mut u8) {
         // Cast the output line to a raw pointer.
-        let out_ptr: *mut [u8; Self::key_len] =
-            slice::from_raw_parts_mut(key_pointer, Self::key_len).as_mut_ptr()
-                as *mut [u8; LeKey::key_len];
+        let out_ptr: *mut [u8; Self::KEY_LEN] =
+            slice::from_raw_parts_mut(key_pointer, Self::KEY_LEN).as_mut_ptr()
+                as *mut [u8; LeKey::KEY_LEN];
         // Get a mutable reference.
-        let out_ref: &mut [u8; Self::key_len] = &mut *out_ptr;
+        let out_ref: &mut [u8; Self::KEY_LEN] = &mut *out_ptr;
         // Write the key.
         write_key_to_array(&self, out_ref);
     }
 
     unsafe fn from_raw_line(key_pointer: *const u8) -> Self {
-        let key_ptr = slice::from_raw_parts(key_pointer, Self::key_len).as_ptr()
-            as *const [u8; Self::key_len];
+        let key_ptr = slice::from_raw_parts(key_pointer, Self::KEY_LEN).as_ptr()
+            as *const [u8; Self::KEY_LEN];
         read_key_from_array(&*key_ptr)
     }
 }
@@ -127,7 +127,7 @@ impl FSSKey for LeKey {
 /// Serialization functions
 ///
 
-fn write_key_to_array(key: &LeKey, array: &mut [u8; LeKey::key_len]) {
+fn write_key_to_array(key: &LeKey, array: &mut [u8; LeKey::KEY_LEN]) {
     array[0..N].copy_from_slice(&key.alpha_share.to_le_bytes());
     array[N..(N + L)].copy_from_slice(&key.s.to_le_bytes());
     for i in 0..(N * 8) {
@@ -152,7 +152,7 @@ fn write_key_to_array(key: &LeKey, array: &mut [u8; LeKey::key_len]) {
     }
 }
 
-fn read_key_from_array(array: &[u8; LeKey::key_len]) -> LeKey {
+fn read_key_from_array(array: &[u8; LeKey::KEY_LEN]) -> LeKey {
     let alpha_share = u32::from_le_bytes(array[0..N].try_into().unwrap());
     let s = u128::from_le_bytes(array[N..(N + L)].try_into().unwrap());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,8 @@ pub unsafe extern "C" fn keygen(
     // Force Rayon to use the number of thread provided by the user, unless a pool already exists
     rayon::ThreadPoolBuilder::new()
         .num_threads(n_threads)
-        .build_global();
+        .build_global()
+        .expect("A pool already exists");
     key_stream_args.par_iter().for_each(create_keypair);
 }
 
@@ -155,6 +156,7 @@ pub unsafe extern "C" fn eval(
     // Force Rayon to use the number of thread provided by the user, unless a pool already exists
     rayon::ThreadPoolBuilder::new()
         .num_threads(n_threads)
-        .build_global();
+        .build_global()
+        .expect("A pool already exists");
     key_stream_args.par_iter().for_each(eval_key);
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -16,7 +16,7 @@ pub trait FSSKey: Sized {
 }
 
 pub trait RawKey: Sized {
-    const key_len: usize;
+    const KEY_LEN: usize;
 
     unsafe fn from_raw_line(raw_line_pointer: *const u8) -> Self;
 
@@ -55,14 +55,14 @@ pub fn generate_key_stream(
     for line_counter in 0..stream_length {
         if op_id == 0 {
             let (key_a, key_b) = EqKey::generate_keypair(&mut prg);
-            let key_len = EqKey::key_len;
+            let key_len = EqKey::KEY_LEN;
             unsafe {
                 &key_a.to_raw_line(key_a_p.add(key_len * line_counter));
                 &key_b.to_raw_line(key_b_p.add(key_len * line_counter));
             }
         } else {
             let (key_a, key_b) = LeKey::generate_keypair(&mut prg);
-            let key_len = LeKey::key_len;
+            let key_len = LeKey::KEY_LEN;
             unsafe {
                 &key_a.to_raw_line(key_a_p.add(key_len * line_counter));
                 &key_b.to_raw_line(key_b_p.add(key_len * line_counter));
@@ -99,11 +99,11 @@ pub fn eval_key_stream(
             let x: u32 = u32::from_le_bytes(*x_ptr);
 
             if op_id == 0 {
-                let key = EqKey::from_raw_line(key_pointer_p.add(EqKey::key_len * line_counter));
+                let key = EqKey::from_raw_line(key_pointer_p.add(EqKey::KEY_LEN * line_counter));
                 let result: u32 = key.eval(&mut prg, party_id, x);
                 *(result_ptr_p.add(line_counter)) = result as i64;
             } else {
-                let key = LeKey::from_raw_line(key_pointer_p.add(LeKey::key_len * line_counter));
+                let key = LeKey::from_raw_line(key_pointer_p.add(LeKey::KEY_LEN * line_counter));
                 let result: u32 = key.eval(&mut prg, party_id, x);
                 *(result_ptr_p.add(line_counter)) = result as i64;
             }


### PR DESCRIPTION
## Description
Closes #14.

Warnings have been removed and tarpaulin tests seem to work.
Executing `RUSTFLAGS="-C target-feature=+aes,+ssse3" cargo tarpaulin` results in

![image](https://user-images.githubusercontent.com/20444151/117512986-fbd31c00-af90-11eb-855f-6429ffc03f0c.png)


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A) No, because I cannot
- [x] My changes are covered by tests
