### PR TITLE
Replace `aesni` crate with `aes`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-rustflags = ["--emit=asm", "-C", "target-feature=+aes,+ssse3"]
+rustflags = ["--emit=asm"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--emit=asm"]

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -95,7 +95,6 @@ jobs:
         with:
           name: Clippy
           token: ${{ secrets.GITHUB_TOKEN }}
-          # args: --all-features --all-targets -- -D warnings
           args: --all-features --all-targets
 
   codecov:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,9 +1,5 @@
 name: Rust Tests
 
-# Ask the Rust compiler to use AESNI
-env:
-  RUSTFLAGS: "-C target-feature=+aes,+ssse3"
-
 on:
   push:
     branches:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 maturin = "0.8.2"
-aesni = "0.10.0"
+aes = "0.7.4"
 rand = "0.7.3"
 rayon = "1.5.0"
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
-use aesni::cipher::generic_array::GenericArray;
-use aesni::cipher::{BlockCipher, NewBlockCipher};
-use aesni::Aes128;
+use aes::cipher::generic_array::GenericArray;
+use aes::Aes128;
+use aes::{BlockCipher, BlockEncrypt, NewBlockCipher};
 use std::slice;
 
 use super::stream::PRG;
@@ -61,7 +61,7 @@ impl PRG for MMO {
     fn from_slice(aes_keys: &[u128]) -> MMO {
         let mut ciphers = vec![];
         for key in aes_keys {
-            ciphers.push(aesni::Aes128::new(GenericArray::from_slice(
+            ciphers.push(aes::Aes128::new(GenericArray::from_slice(
                 &key.to_le_bytes(),
             )));
         }
@@ -74,7 +74,7 @@ impl PRG for MMO {
     fn from_vec(aes_keys: &Vec<u128>) -> MMO {
         let mut ciphers = vec![];
         for key in aes_keys {
-            ciphers.push(aesni::Aes128::new(GenericArray::from_slice(
+            ciphers.push(aes::Aes128::new(GenericArray::from_slice(
                 &key.to_le_bytes(),
             )));
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use aes::cipher::generic_array::GenericArray;
 use aes::Aes128;
-use aes::{BlockCipher, BlockEncrypt, NewBlockCipher};
+use aes::{BlockEncrypt, NewBlockCipher};
 use std::slice;
 
 use super::stream::PRG;


### PR DESCRIPTION
## Description

Since the [`aesni`](https://docs.rs/aesni/0.10.0/aesni/) crate restricts the supported backends, this was causing some problems related to the usage of `SyMPC` on `aarch64` architectures (See https://github.com/OpenMined/SyMPC/issues/286). Replacing this crate with [`aes`](https://docs.rs/aes/0.7.4/aes/) will help because, by default, _"it performs runtime detection of CPU intrinsics and uses them if they are available"_.

Also, I removed the flags in the Cargo config:

* `--emit=asm` because it was causing problems with Clippy, while `cargo bench` can be run just fine without it.
* `-Ctarget-feature=+aes,+ssse3` because otherwise we would be forcing AES-NI as mentioned [here](https://docs.rs/aes/0.7.4/aes/#x86x86_64-intrinsics-aes-ni).


Closes #24 

## Affected Dependencies
aesni -> aes

## How has this been tested?
- cargo / pytest

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
