### PR TITLE
Add `bench = false` to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ harness = false
 [lib]
 name = "sycret"
 crate-type = ["cdylib", "rlib"]
+bench = false
 
 [package.metadata.maturin]
 maintainer = "Pierre Tholoniat"


### PR DESCRIPTION
## Description

This should solve issue with benches

See:
https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
https://github.com/bheisler/criterion.rs/issues/193#issuecomment-415740713

## Affected Dependencies
.

## How has this been tested?
The workflow could not run the benchmarks because this is still missing in master. See [this PR](https://github.com/OpenMined/sycret/pull/26).

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
