### PR TITLE
Remove borrows that were causing a build warning

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -57,15 +57,15 @@ pub fn generate_key_stream(
             let (key_a, key_b) = EqKey::generate_keypair(&mut prg);
             let key_len = EqKey::KEY_LEN;
             unsafe {
-                &key_a.to_raw_line(key_a_p.add(key_len * line_counter));
-                &key_b.to_raw_line(key_b_p.add(key_len * line_counter));
+                key_a.to_raw_line(key_a_p.add(key_len * line_counter));
+                key_b.to_raw_line(key_b_p.add(key_len * line_counter));
             }
         } else {
             let (key_a, key_b) = LeKey::generate_keypair(&mut prg);
             let key_len = LeKey::KEY_LEN;
             unsafe {
-                &key_a.to_raw_line(key_a_p.add(key_len * line_counter));
-                &key_b.to_raw_line(key_b_p.add(key_len * line_counter));
+                key_a.to_raw_line(key_a_p.add(key_len * line_counter));
+                key_b.to_raw_line(key_b_p.add(key_len * line_counter));
             }
         }
     }


### PR DESCRIPTION
## Description
We were getting a build warning (`warning: unused borrow that must be used`) that we can avoid by removing these borrows without affecting anything else.

## Affected Dependencies
.

## How has this been tested?
I ran the build command

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
