### PR TITLE
Pin maturin version in GitHub Actions

### DIFF
--- a/.github/workflows/ pythonpublish-linux.yml
+++ b/.github/workflows/ pythonpublish-linux.yml
@@ -30,7 +30,7 @@ jobs:
       - name: maturin build
         run: |
           pip install --upgrade pip
-          pip install --no-cache-dir cffi maturin
+          pip install --no-cache-dir cffi maturin==0.8.2
           maturin build -b cffi --release
       - name: Publish with Maturin
         run: maturin publish -b cffi --no-sdist -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1
 cffi>=1
 pycparser>=2
-maturin==0.11.3
+maturin==0.8.2
 mkdocs==1.1.2
 mkdocs-material==6.2.4
 mkdocs-material-extensions==1.0.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1
 cffi>=1
 pycparser>=2
-maturin==0.8.2
+maturin==0.11.3
 mkdocs==1.1.2
 mkdocs-material==6.2.4
 mkdocs-material-extensions==1.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [tool.maturin]
 bindings = "cffi"
-compatibility = "2010"
+manylinux = "2010"
 
 [tool.isort]
 multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [tool.maturin]
 bindings = "cffi"
-compatibility = "linux"
+compatibility = "2010"
 
 [tool.isort]
 multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [tool.maturin]
 bindings = "cffi"
-manylinux = "2010"
+compatibility = "linux"
 
 [tool.isort]
 multi_line_output = 3


### PR DESCRIPTION
## Description

This will fix the build fail for the release. I think it's better to pin down the version we will use here so that changes in Maturin don't break our pipeline. However I also think it's time to update the Maturin version we're using, so I created a separate issue for that: https://github.com/OpenMined/sycret/issues/39

## Affected Dependencies


## How has this been tested?
Ran locally

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
