### PR TITLE
Update maturin

### DIFF
--- a/.github/workflows/ pythonpublish-linux.yml
+++ b/.github/workflows/ pythonpublish-linux.yml
@@ -30,7 +30,7 @@ jobs:
       - name: maturin build
         run: |
           pip install --upgrade pip
-          pip install --no-cache-dir cffi maturin
+          pip install --no-cache-dir cffi maturin==0.11.4b5
           maturin build -b cffi --release
       - name: Publish with Maturin
         run: maturin publish -b cffi --no-sdist -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1
 cffi>=1
 pycparser>=2
-maturin==0.11.3
+maturin==0.11.4b5
 mkdocs==1.1.2
 mkdocs-material==6.2.4
 mkdocs-material-extensions==1.0.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1
 cffi>=1
 pycparser>=2
-maturin==0.8.2
+maturin==0.11.3
 mkdocs==1.1.2
 mkdocs-material==6.2.4
 mkdocs-material-extensions==1.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin"]
+requires = ["maturin>=0.11,<.12"]
 build-backend = "maturin"
 
 [tool.maturin]

--- a/sycret/sycret/__init__.py
+++ b/sycret/sycret/__init__.py
@@ -3,5 +3,5 @@ __all__ = ["lib", "ffi"]
 import os
 from .ffi import ffi
 
-lib = ffi.dlopen(os.path.join(os.path.dirname(__file__), 'native.so'), 4098)
+lib = ffi.dlopen(os.path.join(os.path.dirname(__file__), 'native.so'))
 del os


### PR DESCRIPTION
## Description

We can now use the latest version of `maturin` (with [this pre-release](https://github.com/PyO3/maturin/issues/636#issuecomment-927551321)). 

## Affected Dependencies

maturin==0.8.2 -> maturin==0.11.4b5

## How has this been tested?
This was tested locally.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
