### PR TITLE
Update manylinux `2010` -> `2014`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [tool.maturin]
 bindings = "cffi"
-manylinux = "2010"
+manylinux = "2014"
 
 [tool.isort]
 multi_line_output = 3

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup_dir = Path(__file__).resolve().parent
 
 setup(
     name="sycret",
-    version="0.2.1",
+    version="0.2.2",
     author="Pierre Tholoniat",
     author_email="pierre@tholoniat.com",
     url="https://github.com/OpenMined/sycret",


### PR DESCRIPTION
## Description

Sycret is still not working correctly in ARM architectures. It seems that ARM support was added with `manylinux2014`. See [this](https://github.com/PyO3/maturin/issues/237) for example. So this PR changes the manylinux flag and bumps the sycret version.

## Affected Dependencies


## How has this been tested?
Tested locally.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
