### PR TITLE
Fix manylinux-2010 build

### DIFF
--- a/.github/workflows/pythonpublish-linux.yml
+++ b/.github/workflows/pythonpublish-linux.yml
@@ -53,5 +53,5 @@ jobs:
           . $HOME/.cargo/env
           yum install -y rh-python36
           scl enable rh-python36 bash
-          pip install --no-cache-dir cffi maturin==0.11.4
+          python3.6 -m pip install --no-cache-dir cffi maturin==0.11.4
           maturin publish -b cffi --no-sdist -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} --manylinux 2010


### PR DESCRIPTION
## Description
Currently, our publishing workflow with the `quay.io/pypa/manylinux2010_x86_64` container is failing with: 

```
pip: command not found
```

I think this change ought to fix it.

## Affected Dependencies
No.

## How has this been tested?
Ran the commands in the container

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
